### PR TITLE
Add support for videos in CPE

### DIFF
--- a/radio/radio_model.py
+++ b/radio/radio_model.py
@@ -146,6 +146,21 @@ class RADIOModel(nn.Module):
         if fn is not None:
             fn()
 
+    def cpe_video_mode(self, t: int):
+        '''
+        Context Manager.
+
+        Puts the patch generator into video mode, with the specified number of temporal frames.
+        In video mode, the expectation is that the input buffer is of shape `(B*T, C, H, W)`.
+        Video mode means that the same position viewport will be used for every frame in the temporal sequence, while keeping
+        distinct viewports for each video in the batch.
+
+        Usage:
+        with radio_model.cpe_video_mode(t=t):
+            y = radio_model(x)
+        '''
+        return self.model.cpe_video_mode(t)
+
     def forward(self, x: torch.Tensor, feature_fmt: str = 'NLC') -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         '''
         Forward process for model.

--- a/test_video_mode.py
+++ b/test_video_mode.py
@@ -1,0 +1,13 @@
+import sys
+import torch
+from hubconf import radio_model
+
+
+if __name__ == "__main__":
+    model = radio_model(version=sys.argv[1] if len(sys.argv) > 1 else '').cuda()
+
+    x = torch.rand(8, 3, 192, 192, device='cuda')
+
+    with model.cpe_video_mode(t=4):
+        y = model(x)
+    pass


### PR DESCRIPTION
Adds the `def cpe_video_mode(self, t: int)` function to RADIOModel, which is a context manager that will cause CPE to reinterpret the `(B,C,H,W)` input tensor to instead be `(B*T,C,H,W)`. Because of this, all T frames will get the same random position crop, while different videos will get different crops. Without this mode, each frame would get a different position tensor, which could cause confusion down the line.

Usage:
```
        with radio_model.cpe_video_mode(t=t):
            y = radio_model(x)
```